### PR TITLE
CSRF token validation

### DIFF
--- a/client/hardening.ts
+++ b/client/hardening.ts
@@ -1,0 +1,26 @@
+function getCookie (cname) {
+	const name = cname + '=';
+	const decodedCookie = decodeURIComponent(document.cookie);
+	const ca = decodedCookie.split(';');
+	for (let i = 0; i < ca.length; i++) {
+		let c = ca[i];
+		while (c.charAt(0) === ' ') {
+			c = c.substring(1);
+		}
+		if (c.indexOf(name) === 0) {
+			return c.substring(name.length, c.length);
+		}
+	}
+	return '';
+}
+
+// Inject CSRF into forms present within the document
+const formsInDOM = [...document.getElementsByTagName('form')];
+formsInDOM.forEach(form => {
+	console.log(getCookie('CSRFToken'));
+	const input = document.createElement('input');
+	input.name = '__CSRFToken';
+	input.type = 'hidden';
+	input.value = getCookie('CSRFToken');
+	form.appendChild(input);
+});

--- a/client/rollup.config.js
+++ b/client/rollup.config.js
@@ -22,5 +22,12 @@ export default [
 			format: 'es'
 		},
 		plugins: [scss({output:'./static/lapa/headerstyle.css'})].concat(plugins)
+	},
+	{
+		input: './client/hardening.ts',
+		output: {
+			file: './static/js/hardening.js',
+			format: 'es'
+		}
 	}
 ];

--- a/source/example.config.ts
+++ b/source/example.config.ts
@@ -16,3 +16,10 @@ export const authorization = {
 	/** secret used to sign JWTs and HMACs */
 	secret: 'Please change me :)'
 };
+export const session = {
+	/** lifetime of the session id token in the browser */
+	tokenLife: 90_000,
+
+	/** secret used to sign JWTs and HMACs */
+	secret: authorization.secret // It can be the same as auth secret I think
+};

--- a/source/index.ts
+++ b/source/index.ts
@@ -7,6 +7,7 @@ import { sequelize } from './sequelizeSetup.js';
 import { controllerRouter } from './controllers/index.js';
 import { validateAuthToken } from './middleware/AuthTokenMiddleware.js';
 import { headerConstants } from './controllers/config.js';
+import { identifySession, obfuscateServerInfo, validateCSRF } from './middleware/HardeningMiddleware.js';
 // import { type AuthenticatedRequest, authenticator, router as userRouter } from './routes/UserController';
 
 const app: express.Application = express();
@@ -25,6 +26,9 @@ app.use(BodyParser.urlencoded({ // to support URL-encoded bodies
 	extended: true
 }));
 app.use(validateAuthToken); // To parse authentification tokens
+app.use(identifySession); // To fingerprint the session
+app.use(validateCSRF); // To validate the CSRF token for non-GET requests
+app.use(obfuscateServerInfo); // To hide server-identifying headers
 
 app.use('/', controllerRouter());
 

--- a/source/middleware/HardeningMiddleware.ts
+++ b/source/middleware/HardeningMiddleware.ts
@@ -1,0 +1,47 @@
+import type { Request, Response, NextFunction } from 'express';
+import { randomBytes } from 'crypto';
+import { session as config } from '../config.js';
+import jwt from 'jsonwebtoken';
+
+export async function identifySession (req: Request, res: Response, next: NextFunction): Promise<void> {
+	if (req.cookies.SessionId === undefined) {
+		const sessionId = randomBytes(32).toString('hex');
+		res.cookie('SessionId', sessionId, { maxAge: config.tokenLife * 1000, sameSite: 'strict', secure: true });
+		res.locals.sessionId = sessionId;
+	} else {
+		res.locals.sessionId = req.cookies.SessionId;
+	}
+	next();
+}
+
+export async function validateCSRF (req: Request, res: Response, next: NextFunction): Promise<void> {
+	if (res.locals.sessionId === undefined) {
+		res.sendStatus(400);
+	} else if (req.method === 'GET') {
+		/* Generate CSRF */
+		const payload: object = {
+			sub: res.locals.sessionId
+		};
+		const CSRFtoken = jwt.sign(payload, config.secret, { expiresIn: config.tokenLife });
+		res.cookie('CSRFToken', CSRFtoken, { maxAge: config.tokenLife * 1000, sameSite: 'strict', secure: true });
+		next();
+	} else {
+		/* Check CSRF */
+		const CSRFtoken = req.body.__CSRFToken;
+		if (CSRFtoken === undefined) {
+			res.sendStatus(403);
+		} else {
+			const CSRFdata = jwt.verify(CSRFtoken, config.secret);
+			if (typeof CSRFdata !== 'string') {
+				next();
+			} else {
+				res.sendStatus(403);
+			}
+		}
+	}
+}
+
+export async function obfuscateServerInfo (req: Request, res: Response, next: NextFunction): Promise<void> {
+	res.removeHeader('X-Powered-By');
+	next();
+}

--- a/source/types.d.ts
+++ b/source/types.d.ts
@@ -5,6 +5,10 @@ declare global {
 		interface Locals {
 			/** Undefined before the authentification middleware is run, otherwise contains the user if they are logged in. */
 			user?: User | null;
+			/** Undefined before the session id middleware is run, otherwise contains the session id. */
+			sessionId?: string;
+			/** Undefined before the CSRF middleware is run, otherwise contains the CSRF token. */
+			csrfToken?: string;
 		}
 	}
 }

--- a/views/pages/misc/hardening.ejs
+++ b/views/pages/misc/hardening.ejs
@@ -1,0 +1,4 @@
+<div id="ignore_me" hidden>
+<!-- CSRF stuff, should hopefully be an "add and forget" in other views -->
+<script src="../js/hardening.js" defer></script>
+</div>

--- a/views/pages/misc/header.ejs
+++ b/views/pages/misc/header.ejs
@@ -1,3 +1,4 @@
+<%- include('../misc/hardening.ejs') %>
 <header class ="topbars">
 	
 	<link rel="stylesheet" href="/lapa/headerstyle.css">

--- a/views/pages/user/login.ejs
+++ b/views/pages/user/login.ejs
@@ -7,6 +7,7 @@
     <title>Login</title>
 </head>
 <body>
+    <%- include('../misc/hardening.ejs') %>
     <link rel="stylesheet" href="/lapa/headerstyle.css">
 	<div class="nav_buttons">
 		<a href="<%=constants.section%>" id="home_button"><%=constants.home_button%></a>

--- a/views/pages/user/signup.ejs
+++ b/views/pages/user/signup.ejs
@@ -7,6 +7,7 @@
     <title>Sign up form</title>
 </head>
 <body>
+    <%- include('../misc/hardening.ejs') %>
     <link rel="stylesheet" href="/lapa/headerstyle.css">
 	<div class="nav_buttons">
 		<a href="<%=constants.section%>" id="home_button"><%=constants.home_button%></a>


### PR DESCRIPTION
The server now creates a cookie with a CSRF token bound to the current session id and with a preset expiry date.
The client then reads the token from the cookie and injects it in any form in the document, ensuring that the request is included in any POST request sent to the server.