### PR TITLE
CSRF middleware fixes

### DIFF
--- a/client/hardening.ts
+++ b/client/hardening.ts
@@ -25,10 +25,12 @@ formsInDOM.forEach(form => {
 });
 
 // Custom fetch request that injects the CSRF token into the body
-export async function fetchWithCSRF (url: string, headers: Headers, body: any): Promise<Response> {
+export async function fetchWithCSRF (url: string, requestInit: RequestInit): Promise<Response> {
+	const body = requestInit.body ?? {};
 	const bodyWithCSRF = { ...body, __CSRFToken: getCookie('CSRFToken') };
-	const headersWithJSON = { ...headers, 'content-type': 'application/json' };
+	const headersWithJSON = { ...(requestInit.headers ?? {}), 'content-type': 'application/json' };
 	return await fetch(url, {
+		...requestInit,
 		headers: headersWithJSON,
 		body: JSON.stringify(bodyWithCSRF)
 	});

--- a/client/hardening.ts
+++ b/client/hardening.ts
@@ -1,4 +1,4 @@
-function getCookie (cname) {
+function getCookie (cname: string): string {
 	const name = cname + '=';
 	const decodedCookie = decodeURIComponent(document.cookie);
 	const ca = decodedCookie.split(';');
@@ -23,3 +23,13 @@ formsInDOM.forEach(form => {
 	input.value = getCookie('CSRFToken');
 	form.appendChild(input);
 });
+
+// Custom fetch request that injects the CSRF token into the body
+export async function fetchWithCSRF (url: string, headers: Headers, body: any): Promise<Response> {
+	const bodyWithCSRF = { ...body, __CSRFToken: getCookie('CSRFToken') };
+	const headersWithJSON = { ...headers, 'content-type': 'application/json' };
+	return await fetch(url, {
+		headers: headersWithJSON,
+		body: JSON.stringify(bodyWithCSRF)
+	});
+}

--- a/client/rollup.config.js
+++ b/client/rollup.config.js
@@ -28,6 +28,7 @@ export default [
 		output: {
 			file: './static/js/hardening.js',
 			format: 'es'
-		}
+		},
+		plugins: plugins
 	}
 ];

--- a/source/middleware/HardeningMiddleware.ts
+++ b/source/middleware/HardeningMiddleware.ts
@@ -32,7 +32,7 @@ export async function validateCSRF (req: Request, res: Response, next: NextFunct
 			res.sendStatus(403);
 		} else {
 			const CSRFdata = jwt.verify(CSRFtoken, config.secret);
-			if (typeof CSRFdata !== 'string') {
+			if (typeof CSRFdata !== 'string' && CSRFdata.sub === res.locals.sessionId) {
 				next();
 			} else {
 				res.sendStatus(403);

--- a/source/middleware/HardeningMiddleware.ts
+++ b/source/middleware/HardeningMiddleware.ts
@@ -28,7 +28,7 @@ export async function validateCSRF (req: Request, res: Response, next: NextFunct
 	} else {
 		/* Check CSRF */
 		const CSRFtoken = req.body.__CSRFToken;
-		if (CSRFtoken === undefined) {
+		if (CSRFtoken === undefined || typeof CSRFtoken !== 'string') {
 			res.sendStatus(403);
 		} else {
 			const CSRFdata = jwt.verify(CSRFtoken, config.secret);


### PR DESCRIPTION
- Added check to ensure the CSRF token is valid for the session id
- Added check to ensure that the CSRF token is string
- Added a client-side function that injects CSRF token into the body before calling fetch