### PR TITLE
CSRF Middleware Hotfix

### DIFF
--- a/client/hardening.ts
+++ b/client/hardening.ts
@@ -27,7 +27,11 @@ formsInDOM.forEach(form => {
 // Custom fetch request that injects the CSRF token into the body
 export async function fetchWithCSRF (url: string, requestInit: RequestInit): Promise<Response> {
 	const body = requestInit.body ?? {};
-	const bodyWithCSRF = { ...body, __CSRFToken: getCookie('CSRFToken') };
+	const tokenRaw: string | string[] = getCookie('CSRFToken');
+	let token = '';
+	if (Array.isArray(tokenRaw)) token = tokenRaw[tokenRaw.length - 1];
+	else token = tokenRaw;
+	const bodyWithCSRF = { ...body, __CSRFToken: token };
 	const headersWithJSON = { ...(requestInit.headers ?? {}), 'content-type': 'application/json' };
 	return await fetch(url, {
 		...requestInit,

--- a/source/middleware/HardeningMiddleware.ts
+++ b/source/middleware/HardeningMiddleware.ts
@@ -31,10 +31,14 @@ export async function validateCSRF (req: Request, res: Response, next: NextFunct
 		if (CSRFtoken === undefined || typeof CSRFtoken !== 'string') {
 			res.sendStatus(403);
 		} else {
-			const CSRFdata = jwt.verify(CSRFtoken, config.secret);
-			if (typeof CSRFdata !== 'string' && CSRFdata.sub === res.locals.sessionId) {
-				next();
-			} else {
+			try {
+				const CSRFdata = jwt.verify(CSRFtoken, config.secret);
+				if (typeof CSRFdata !== 'string' && CSRFdata.sub === res.locals.sessionId) {
+					next();
+				} else {
+					res.sendStatus(403);
+				}
+			} catch (e) {
 				res.sendStatus(403);
 			}
 		}


### PR DESCRIPTION
- JWT Exceptions are handled (should resolve malformed CSRF tokens crashing the server)
- fetchWithCSRF now properly handles the CSRFToken cookie occasionally being an array