### PR TITLE
HTTPS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ files
 static/**
 .vs
 .vscode
+
+# HTTPS certs, shouldn't appear on git considering every system should have its own
+**/server.cert
+**/server.key

--- a/source/example.config.ts
+++ b/source/example.config.ts
@@ -28,3 +28,11 @@ export const logging = {
 	/** Minimum log level */
 	logLevel: LogLevel.INFO
 };
+export const server = {
+	/** Whether or not this is debug */
+	debug: false,
+	/** HTTPS key location */
+	keyLocation: 'server.key',
+	/** HTTPS cert location */
+	certLocation: 'server.cert'
+};

--- a/tools/generateHTTPScert.sh
+++ b/tools/generateHTTPScert.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# A script to generate a self-signed cert for the project
+# Feel free to enter any info you want, it's not like the CAs are gonna sue you or sth
+
+# Get the root working directory
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+# Run the command to generate the cert and key in the root directory
+echo "Generating cert at $ROOT_DIR..."
+echo -e "\x1b[1;31mOpenSSL will ask you to enter info, feel to enter any info you want!\x1b[0m"
+echo ""
+openssl req -nodes -new -x509 -keyout $ROOT_DIR/server.key -out $ROOT_DIR/server.cert
+echo ""
+echo "Done!"


### PR DESCRIPTION
- Configured express to dynamically choose ports depending on whether the project is set to dev or prod mode
- Configured express to accept HTTPS requests using a specified cert
- Added a bash script to dynamically generate self-signed HTTPS certificates